### PR TITLE
ci: Add keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,13 @@
+name: Github Action with a cronjob trigger
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 */5 * *"
+
+jobs:
+  cronjob-based-github-action:
+    name: Cronjob based github action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings


### PR DESCRIPTION
作者您好，您的项目太棒了（，可惜就是如果仓库60天无提交，则github action会自动暂停，于是加了个workflow来防止暂停。

通过使用[gautamkrishnar/keepalive-workflow: GitHub action to prevent GitHub from suspending your cronjob based triggers due to repository inactivity](https://github.com/gautamkrishnar/keepalive-workflow)的workflow，来防止打卡在60天后自动暂停。

暂停后需要重新获取`session-id`

![image](https://user-images.githubusercontent.com/88016816/197967716-cecae4bd-be65-48ee-9785-ec3989d62abe.png)
